### PR TITLE
Allow directly entering GitHub personal access token.

### DIFF
--- a/CCMenu/Source/Pipeline Window/GitHub Sheets/GitHubAuthenticator.swift
+++ b/CCMenu/Source/Pipeline Window/GitHub Sheets/GitHubAuthenticator.swift
@@ -119,6 +119,12 @@ class GitHubAuthenticator: ObservableObject {
         tokenDescription = token ?? ""
     }
 
+    func setToken(_ newToken: String) {
+        let trimmed = newToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        token = trimmed.isEmpty ? nil : trimmed
+        tokenDescription = token ?? ""
+    }
+
     func openApplicationsOnWebsite() {
         NSWorkspace.shared.open(GitHubAPI.applicationsUrl())
     }


### PR DESCRIPTION
Thank you Erik for this fantastic app, it's exactly what I've been looking for.

However, the requested OAuth scope for Github login is too broad for my organisation.

What I found is a workaround, where if I make the authentication field editable in the "Add GitHub Actions workflow" dialog, I can put in a fine-grained PAT with the appropriate permissions (Actions read-only + Contents read-only), I am able to monitor workflows without having to authorize the `repo` scope.

I've tested it with my org's repos and it works fine.

However, I will caveat that the code here is written with AI, and while I read through every line of change, I am not personally familiar with Swift, so if there's a better way to do it, let me know.

Related to discussion #8 
